### PR TITLE
Bump patch version to 0.11.2 and update release notes

### DIFF
--- a/src/OwlCore.Storage.csproj
+++ b/src/OwlCore.Storage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -14,7 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <Product>OwlCore</Product>
     <Description>The most flexible file system abstraction, ever. Built in partnership with the UWP Community.
 		
@@ -23,6 +23,10 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReleaseNotes>
+--- 0.11.2 ---
+[Fixes]
+Fixed an issue where the stream returned from `File.Open` does synchronous operations on the file and didn't support cancellation during read/write. The underlying operating system now gives us an asynchronous file stream to do true async reads/writes.
+
 --- 0.11.1 ---
 [Fixes]
 Fixed an issue where SystemFolderWatcher would not capture any file system events.


### PR DESCRIPTION
Bumps the patch version number and updates the release notes in `src/OwlCore.Storage.csproj`.

- **Version Update**: Increases the `<Version>` tag from `0.11.1` to `0.11.2`.
- **Release Notes Addition**: Adds a new entry under `<PackageReleaseNotes>` for version `0.11.2`, detailing the fix for an issue where the stream returned from `File.Open` did synchronous operations on the file and lacked support for cancellation during read/write operations. This update ensures the underlying operating system now provides an asynchronous file stream for true async reads/writes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arlodotexe/OwlCore.Storage/pull/58?shareId=22481759-1a2d-46b7-bea5-2faa9bdb3f0e).